### PR TITLE
feat: register `stbl_*` C functions as C callables

### DIFF
--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           use-container: "true"
           token: ${{ secrets.GITHUB_TOKEN }}
-          extra-packages: Gilead-BioStats/qcthat@main local::.
+          extra-packages: Gilead-BioStats/qcthat@dev local::.
 
       - name: Manage User Acceptance Testing
         if: >-

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stbl
 Title: Stabilize Function Arguments
-Version: 0.3.0.9000
+Version: 0.3.0.9001
 Authors@R:
     person("Jon", "Harmon", , "jonthegeek@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-4781-4346"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * New `pkg_inform()` signals classed messages with an opinionated class hierarchy, mirroring `pkg_abort()`. New `expect_pkg_message_classes()` tests that a message with the expected set of classes is thrown, and `expect_pkg_message_snapshot()` snapshot-tests the full message output in one step (#213).
 * New `pkg_warn()` signals classed warnings with an opinionated class hierarchy, mirroring `pkg_abort()`. New `expect_pkg_warning_classes()` tests that a warning with the expected set of classes is thrown, and `expect_pkg_warning_snapshot()` snapshot-tests the full warning output in one step (#213).
+* The C functions underlying `are_*_ish()`, `to_*()`, and range checks are now registered as C callables via `R_RegisterCCallable()`, making them available to other packages. Include `inst/include/stbl.h` and `inst/include/stbl.c` in a dependent package and call `stbl_init_api()` at load time to use them (#235).
 * Many `are_*_ish()` and `to_*()` methods are now implemented in C. Benchmarks show a significant speedup (about 3-20x) for large vectors (#217, #218, #219, #221, #226).
 * `is_fct_ish()` now accepts a `max_levels` argument to limit the number of unique non-`NA` levels (#231).
 * `stabilize_dbl()` and `stabilize_int()` now use a C implementation for min/max range checks, improving throughput for large vectors (#220).

--- a/inst/include/stbl.c
+++ b/inst/include/stbl.c
@@ -1,0 +1,98 @@
+#include "stbl.h"
+
+/* chr -> * */
+SEXP (*stbl_chr_to_lgl)(SEXP)             = NULL;
+SEXP (*stbl_chr_are_lglish)(SEXP)         = NULL;
+SEXP (*stbl_chr_to_int)(SEXP)             = NULL;
+SEXP (*stbl_chr_are_intish)(SEXP)         = NULL;
+SEXP (*stbl_chr_to_dbl)(SEXP)             = NULL;
+SEXP (*stbl_chr_are_dblish)(SEXP)         = NULL;
+SEXP (*stbl_chr_are_fctish)(SEXP, SEXP, SEXP) = NULL;
+
+/* dbl -> * */
+SEXP (*stbl_dbl_to_int)(SEXP)             = NULL;
+SEXP (*stbl_dbl_are_intish)(SEXP)         = NULL;
+SEXP (*stbl_dbl_to_lgl)(SEXP)             = NULL;
+SEXP (*stbl_dbl_are_lglish)(SEXP)         = NULL;
+
+/* int -> * */
+SEXP (*stbl_int_to_dbl)(SEXP)             = NULL;
+SEXP (*stbl_int_are_dblish)(SEXP)         = NULL;
+
+/* lgl -> * */
+SEXP (*stbl_lgl_to_dbl)(SEXP)             = NULL;
+SEXP (*stbl_lgl_are_dblish)(SEXP)         = NULL;
+SEXP (*stbl_lgl_to_int)(SEXP)             = NULL;
+SEXP (*stbl_lgl_are_intish)(SEXP)         = NULL;
+
+/* cpx -> * */
+SEXP (*stbl_cpx_to_dbl)(SEXP)             = NULL;
+SEXP (*stbl_cpx_are_dblish)(SEXP)         = NULL;
+SEXP (*stbl_cpx_to_int)(SEXP)             = NULL;
+SEXP (*stbl_cpx_are_intish)(SEXP)         = NULL;
+
+/* fct -> * */
+SEXP (*stbl_fct_to_dbl)(SEXP)             = NULL;
+SEXP (*stbl_fct_are_dblish)(SEXP)         = NULL;
+SEXP (*stbl_fct_to_int)(SEXP)             = NULL;
+SEXP (*stbl_fct_are_intish)(SEXP)         = NULL;
+SEXP (*stbl_fct_to_lgl)(SEXP)             = NULL;
+SEXP (*stbl_fct_are_lglish)(SEXP)         = NULL;
+SEXP (*stbl_fct_are_fctish)(SEXP, SEXP, SEXP) = NULL;
+
+/* lst -> * */
+SEXP (*stbl_lst_to_dbl)(SEXP)             = NULL;
+SEXP (*stbl_lst_to_int)(SEXP)             = NULL;
+SEXP (*stbl_lst_to_lgl)(SEXP)             = NULL;
+SEXP (*stbl_lst_to_chr)(SEXP)             = NULL;
+SEXP (*stbl_lst_to_fct)(SEXP)             = NULL;
+
+/* range checks */
+SEXP (*stbl_check_min_dbl)(SEXP, SEXP)    = NULL;
+SEXP (*stbl_check_max_dbl)(SEXP, SEXP)    = NULL;
+
+void stbl_init_api(void) {
+  /* chr -> * */
+  stbl_chr_to_lgl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_chr_to_lgl");
+  stbl_chr_are_lglish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_chr_are_lglish");
+  stbl_chr_to_int     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_chr_to_int");
+  stbl_chr_are_intish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_chr_are_intish");
+  stbl_chr_to_dbl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_chr_to_dbl");
+  stbl_chr_are_dblish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_chr_are_dblish");
+  stbl_chr_are_fctish = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("stbl", "stbl_chr_are_fctish");
+  /* dbl -> * */
+  stbl_dbl_to_int     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_dbl_to_int");
+  stbl_dbl_are_intish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_dbl_are_intish");
+  stbl_dbl_to_lgl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_dbl_to_lgl");
+  stbl_dbl_are_lglish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_dbl_are_lglish");
+  /* int -> * */
+  stbl_int_to_dbl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_int_to_dbl");
+  stbl_int_are_dblish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_int_are_dblish");
+  /* lgl -> * */
+  stbl_lgl_to_dbl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lgl_to_dbl");
+  stbl_lgl_are_dblish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lgl_are_dblish");
+  stbl_lgl_to_int     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lgl_to_int");
+  stbl_lgl_are_intish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lgl_are_intish");
+  /* cpx -> * */
+  stbl_cpx_to_dbl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_cpx_to_dbl");
+  stbl_cpx_are_dblish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_cpx_are_dblish");
+  stbl_cpx_to_int     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_cpx_to_int");
+  stbl_cpx_are_intish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_cpx_are_intish");
+  /* fct -> * */
+  stbl_fct_to_dbl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_fct_to_dbl");
+  stbl_fct_are_dblish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_fct_are_dblish");
+  stbl_fct_to_int     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_fct_to_int");
+  stbl_fct_are_intish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_fct_are_intish");
+  stbl_fct_to_lgl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_fct_to_lgl");
+  stbl_fct_are_lglish = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_fct_are_lglish");
+  stbl_fct_are_fctish = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("stbl", "stbl_fct_are_fctish");
+  /* lst -> * */
+  stbl_lst_to_dbl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lst_to_dbl");
+  stbl_lst_to_int     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lst_to_int");
+  stbl_lst_to_lgl     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lst_to_lgl");
+  stbl_lst_to_chr     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lst_to_chr");
+  stbl_lst_to_fct     = (SEXP (*)(SEXP))             R_GetCCallable("stbl", "stbl_lst_to_fct");
+  /* range checks */
+  stbl_check_min_dbl  = (SEXP (*)(SEXP, SEXP))       R_GetCCallable("stbl", "stbl_check_min_dbl");
+  stbl_check_max_dbl  = (SEXP (*)(SEXP, SEXP))       R_GetCCallable("stbl", "stbl_check_max_dbl");
+}

--- a/inst/include/stbl.h
+++ b/inst/include/stbl.h
@@ -1,0 +1,60 @@
+#ifndef STBL_API_H
+#define STBL_API_H
+
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+
+/* chr -> * */
+extern SEXP (*stbl_chr_to_lgl)(SEXP);
+extern SEXP (*stbl_chr_are_lglish)(SEXP);
+extern SEXP (*stbl_chr_to_int)(SEXP);
+extern SEXP (*stbl_chr_are_intish)(SEXP);
+extern SEXP (*stbl_chr_to_dbl)(SEXP);
+extern SEXP (*stbl_chr_are_dblish)(SEXP);
+extern SEXP (*stbl_chr_are_fctish)(SEXP, SEXP, SEXP);
+
+/* dbl -> * */
+extern SEXP (*stbl_dbl_to_int)(SEXP);
+extern SEXP (*stbl_dbl_are_intish)(SEXP);
+extern SEXP (*stbl_dbl_to_lgl)(SEXP);
+extern SEXP (*stbl_dbl_are_lglish)(SEXP);
+
+/* int -> * */
+extern SEXP (*stbl_int_to_dbl)(SEXP);
+extern SEXP (*stbl_int_are_dblish)(SEXP);
+
+/* lgl -> * */
+extern SEXP (*stbl_lgl_to_dbl)(SEXP);
+extern SEXP (*stbl_lgl_are_dblish)(SEXP);
+extern SEXP (*stbl_lgl_to_int)(SEXP);
+extern SEXP (*stbl_lgl_are_intish)(SEXP);
+
+/* cpx -> * */
+extern SEXP (*stbl_cpx_to_dbl)(SEXP);
+extern SEXP (*stbl_cpx_are_dblish)(SEXP);
+extern SEXP (*stbl_cpx_to_int)(SEXP);
+extern SEXP (*stbl_cpx_are_intish)(SEXP);
+
+/* fct -> * */
+extern SEXP (*stbl_fct_to_dbl)(SEXP);
+extern SEXP (*stbl_fct_are_dblish)(SEXP);
+extern SEXP (*stbl_fct_to_int)(SEXP);
+extern SEXP (*stbl_fct_are_intish)(SEXP);
+extern SEXP (*stbl_fct_to_lgl)(SEXP);
+extern SEXP (*stbl_fct_are_lglish)(SEXP);
+extern SEXP (*stbl_fct_are_fctish)(SEXP, SEXP, SEXP);
+
+/* lst -> * */
+extern SEXP (*stbl_lst_to_dbl)(SEXP);
+extern SEXP (*stbl_lst_to_int)(SEXP);
+extern SEXP (*stbl_lst_to_lgl)(SEXP);
+extern SEXP (*stbl_lst_to_chr)(SEXP);
+extern SEXP (*stbl_lst_to_fct)(SEXP);
+
+/* range checks */
+extern SEXP (*stbl_check_min_dbl)(SEXP, SEXP);
+extern SEXP (*stbl_check_max_dbl)(SEXP, SEXP);
+
+void stbl_init_api(void);
+
+#endif /* STBL_API_H */

--- a/src/init.c
+++ b/src/init.c
@@ -131,4 +131,48 @@ void R_init_stbl(DllInfo* dll) {
   R_registerRoutines(dll, NULL, callMethods, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
   R_forceSymbols(dll, TRUE);
+
+  /* chr -> * */
+  R_RegisterCCallable("stbl", "stbl_chr_to_lgl",      (DL_FUNC) &stbl_chr_to_lgl);
+  R_RegisterCCallable("stbl", "stbl_chr_are_lglish",  (DL_FUNC) &stbl_chr_are_lglish);
+  R_RegisterCCallable("stbl", "stbl_chr_to_int",      (DL_FUNC) &stbl_chr_to_int);
+  R_RegisterCCallable("stbl", "stbl_chr_are_intish",  (DL_FUNC) &stbl_chr_are_intish);
+  R_RegisterCCallable("stbl", "stbl_chr_to_dbl",      (DL_FUNC) &stbl_chr_to_dbl);
+  R_RegisterCCallable("stbl", "stbl_chr_are_dblish",  (DL_FUNC) &stbl_chr_are_dblish);
+  R_RegisterCCallable("stbl", "stbl_chr_are_fctish",  (DL_FUNC) &stbl_chr_are_fctish);
+  /* dbl -> * */
+  R_RegisterCCallable("stbl", "stbl_dbl_to_int",      (DL_FUNC) &stbl_dbl_to_int);
+  R_RegisterCCallable("stbl", "stbl_dbl_are_intish",  (DL_FUNC) &stbl_dbl_are_intish);
+  R_RegisterCCallable("stbl", "stbl_dbl_to_lgl",      (DL_FUNC) &stbl_dbl_to_lgl);
+  R_RegisterCCallable("stbl", "stbl_dbl_are_lglish",  (DL_FUNC) &stbl_dbl_are_lglish);
+  /* int -> * */
+  R_RegisterCCallable("stbl", "stbl_int_to_dbl",      (DL_FUNC) &stbl_int_to_dbl);
+  R_RegisterCCallable("stbl", "stbl_int_are_dblish",  (DL_FUNC) &stbl_int_are_dblish);
+  /* lgl -> * */
+  R_RegisterCCallable("stbl", "stbl_lgl_to_dbl",      (DL_FUNC) &stbl_lgl_to_dbl);
+  R_RegisterCCallable("stbl", "stbl_lgl_are_dblish",  (DL_FUNC) &stbl_lgl_are_dblish);
+  R_RegisterCCallable("stbl", "stbl_lgl_to_int",      (DL_FUNC) &stbl_lgl_to_int);
+  R_RegisterCCallable("stbl", "stbl_lgl_are_intish",  (DL_FUNC) &stbl_lgl_are_intish);
+  /* cpx -> * */
+  R_RegisterCCallable("stbl", "stbl_cpx_to_dbl",      (DL_FUNC) &stbl_cpx_to_dbl);
+  R_RegisterCCallable("stbl", "stbl_cpx_are_dblish",  (DL_FUNC) &stbl_cpx_are_dblish);
+  R_RegisterCCallable("stbl", "stbl_cpx_to_int",      (DL_FUNC) &stbl_cpx_to_int);
+  R_RegisterCCallable("stbl", "stbl_cpx_are_intish",  (DL_FUNC) &stbl_cpx_are_intish);
+  /* fct -> * */
+  R_RegisterCCallable("stbl", "stbl_fct_to_dbl",      (DL_FUNC) &stbl_fct_to_dbl);
+  R_RegisterCCallable("stbl", "stbl_fct_are_dblish",  (DL_FUNC) &stbl_fct_are_dblish);
+  R_RegisterCCallable("stbl", "stbl_fct_to_int",      (DL_FUNC) &stbl_fct_to_int);
+  R_RegisterCCallable("stbl", "stbl_fct_are_intish",  (DL_FUNC) &stbl_fct_are_intish);
+  R_RegisterCCallable("stbl", "stbl_fct_to_lgl",      (DL_FUNC) &stbl_fct_to_lgl);
+  R_RegisterCCallable("stbl", "stbl_fct_are_lglish",  (DL_FUNC) &stbl_fct_are_lglish);
+  R_RegisterCCallable("stbl", "stbl_fct_are_fctish",  (DL_FUNC) &stbl_fct_are_fctish);
+  /* lst -> * */
+  R_RegisterCCallable("stbl", "stbl_lst_to_dbl",      (DL_FUNC) &stbl_lst_to_dbl);
+  R_RegisterCCallable("stbl", "stbl_lst_to_int",      (DL_FUNC) &stbl_lst_to_int);
+  R_RegisterCCallable("stbl", "stbl_lst_to_lgl",      (DL_FUNC) &stbl_lst_to_lgl);
+  R_RegisterCCallable("stbl", "stbl_lst_to_chr",      (DL_FUNC) &stbl_lst_to_chr);
+  R_RegisterCCallable("stbl", "stbl_lst_to_fct",      (DL_FUNC) &stbl_lst_to_fct);
+  /* range checks */
+  R_RegisterCCallable("stbl", "stbl_check_min_dbl",   (DL_FUNC) &stbl_check_min_dbl);
+  R_RegisterCCallable("stbl", "stbl_check_max_dbl",   (DL_FUNC) &stbl_check_max_dbl);
 }

--- a/tests/testthat/helper-callable_c_functions.R
+++ b/tests/testthat/helper-callable_c_functions.R
@@ -1,0 +1,45 @@
+expected_c_symbols <- c(
+  # chr -> *
+  "stbl_chr_to_lgl",
+  "stbl_chr_are_lglish",
+  "stbl_chr_to_int",
+  "stbl_chr_are_intish",
+  "stbl_chr_to_dbl",
+  "stbl_chr_are_dblish",
+  "stbl_chr_are_fctish",
+  # dbl -> *
+  "stbl_dbl_to_int",
+  "stbl_dbl_are_intish",
+  "stbl_dbl_to_lgl",
+  "stbl_dbl_are_lglish",
+  # int -> *
+  "stbl_int_to_dbl",
+  "stbl_int_are_dblish",
+  # lgl -> *
+  "stbl_lgl_to_dbl",
+  "stbl_lgl_are_dblish",
+  "stbl_lgl_to_int",
+  "stbl_lgl_are_intish",
+  # cpx -> *
+  "stbl_cpx_to_dbl",
+  "stbl_cpx_are_dblish",
+  "stbl_cpx_to_int",
+  "stbl_cpx_are_intish",
+  # fct -> *
+  "stbl_fct_to_dbl",
+  "stbl_fct_are_dblish",
+  "stbl_fct_to_int",
+  "stbl_fct_are_intish",
+  "stbl_fct_to_lgl",
+  "stbl_fct_are_lglish",
+  "stbl_fct_are_fctish",
+  # lst -> *
+  "stbl_lst_to_dbl",
+  "stbl_lst_to_int",
+  "stbl_lst_to_lgl",
+  "stbl_lst_to_chr",
+  "stbl_lst_to_fct",
+  # range checks
+  "stbl_check_min_dbl",
+  "stbl_check_max_dbl"
+)

--- a/tests/testthat/test-callable_c_functions.R
+++ b/tests/testthat/test-callable_c_functions.R
@@ -1,0 +1,94 @@
+expected_symbols <- c(
+  # chr -> *
+  "stbl_chr_to_lgl", "stbl_chr_are_lglish",
+  "stbl_chr_to_int", "stbl_chr_are_intish",
+  "stbl_chr_to_dbl", "stbl_chr_are_dblish",
+  "stbl_chr_are_fctish",
+  # dbl -> *
+  "stbl_dbl_to_int", "stbl_dbl_are_intish",
+  "stbl_dbl_to_lgl", "stbl_dbl_are_lglish",
+  # int -> *
+  "stbl_int_to_dbl", "stbl_int_are_dblish",
+  # lgl -> *
+  "stbl_lgl_to_dbl", "stbl_lgl_are_dblish",
+  "stbl_lgl_to_int", "stbl_lgl_are_intish",
+  # cpx -> *
+  "stbl_cpx_to_dbl", "stbl_cpx_are_dblish",
+  "stbl_cpx_to_int", "stbl_cpx_are_intish",
+  # fct -> *
+  "stbl_fct_to_dbl", "stbl_fct_are_dblish",
+  "stbl_fct_to_int", "stbl_fct_are_intish",
+  "stbl_fct_to_lgl", "stbl_fct_are_lglish",
+  "stbl_fct_are_fctish",
+  # lst -> *
+  "stbl_lst_to_dbl", "stbl_lst_to_int", "stbl_lst_to_lgl",
+  "stbl_lst_to_chr", "stbl_lst_to_fct",
+  # range checks
+  "stbl_check_min_dbl", "stbl_check_max_dbl"
+)
+
+# inst/include files -------------------------------------------------------- ----
+
+test_that("inst/include/stbl.h is installed (#235)", {
+  expect_true(nchar(system.file("include", "stbl.h", package = "stbl")) > 0)
+})
+
+test_that("inst/include/stbl.c is installed (#235)", {
+  expect_true(nchar(system.file("include", "stbl.c", package = "stbl")) > 0)
+})
+
+# stbl.h completeness ------------------------------------------------------- ----
+
+test_that("stbl.h declares all expected function pointers (#235)", {
+  h_path <- system.file("include", "stbl.h", package = "stbl")
+  h_text <- paste(readLines(h_path), collapse = "\n")
+  for (sym in expected_symbols) {
+    expect_true(
+      grepl(sym, h_text, fixed = TRUE),
+      label = paste0(sym, " declared in stbl.h")
+    )
+  }
+})
+
+test_that("stbl.h declares stbl_init_api() (#235)", {
+  h_path <- system.file("include", "stbl.h", package = "stbl")
+  h_text <- paste(readLines(h_path), collapse = "\n")
+  expect_true(grepl("stbl_init_api", h_text, fixed = TRUE))
+})
+
+# stbl.c completeness ------------------------------------------------------- ----
+
+test_that("stbl.c assigns all expected callables via R_GetCCallable (#235)", {
+  c_path <- system.file("include", "stbl.c", package = "stbl")
+  c_text <- paste(readLines(c_path), collapse = "\n")
+  for (sym in expected_symbols) {
+    expect_true(
+      grepl(sym, c_text, fixed = TRUE),
+      label = paste0(sym, " assigned in stbl.c")
+    )
+  }
+})
+
+test_that("stbl.c defines stbl_init_api() (#235)", {
+  c_path <- system.file("include", "stbl.c", package = "stbl")
+  c_text <- paste(readLines(c_path), collapse = "\n")
+  expect_true(grepl("stbl_init_api", c_text, fixed = TRUE))
+  expect_true(grepl('R_GetCCallable\\("stbl"', c_text))
+})
+
+# init.c registration ------------------------------------------------------- ----
+
+test_that("src/init.c registers all expected C callables (#235)", {
+  # Locate init.c relative to the test file; only works in source package context.
+  init_path <- test_path("../../src/init.c")
+  if (!file.exists(init_path)) {
+    skip("src/init.c not accessible outside source package")
+  }
+  init_text <- paste(readLines(init_path), collapse = "\n")
+  for (sym in expected_symbols) {
+    expect_true(
+      grepl(sym, init_text, fixed = TRUE),
+      label = paste0(sym, " registered in init.c")
+    )
+  }
+})

--- a/tests/testthat/test-callable_c_functions.R
+++ b/tests/testthat/test-callable_c_functions.R
@@ -1,49 +1,3 @@
-expected_symbols <- c(
-  # chr -> *
-  "stbl_chr_to_lgl",
-  "stbl_chr_are_lglish",
-  "stbl_chr_to_int",
-  "stbl_chr_are_intish",
-  "stbl_chr_to_dbl",
-  "stbl_chr_are_dblish",
-  "stbl_chr_are_fctish",
-  # dbl -> *
-  "stbl_dbl_to_int",
-  "stbl_dbl_are_intish",
-  "stbl_dbl_to_lgl",
-  "stbl_dbl_are_lglish",
-  # int -> *
-  "stbl_int_to_dbl",
-  "stbl_int_are_dblish",
-  # lgl -> *
-  "stbl_lgl_to_dbl",
-  "stbl_lgl_are_dblish",
-  "stbl_lgl_to_int",
-  "stbl_lgl_are_intish",
-  # cpx -> *
-  "stbl_cpx_to_dbl",
-  "stbl_cpx_are_dblish",
-  "stbl_cpx_to_int",
-  "stbl_cpx_are_intish",
-  # fct -> *
-  "stbl_fct_to_dbl",
-  "stbl_fct_are_dblish",
-  "stbl_fct_to_int",
-  "stbl_fct_are_intish",
-  "stbl_fct_to_lgl",
-  "stbl_fct_are_lglish",
-  "stbl_fct_are_fctish",
-  # lst -> *
-  "stbl_lst_to_dbl",
-  "stbl_lst_to_int",
-  "stbl_lst_to_lgl",
-  "stbl_lst_to_chr",
-  "stbl_lst_to_fct",
-  # range checks
-  "stbl_check_min_dbl",
-  "stbl_check_max_dbl"
-)
-
 # inst/include files -------------------------------------------------------- ----
 
 test_that("inst/include/stbl.h is installed (#235)", {
@@ -59,7 +13,7 @@ test_that("inst/include/stbl.c is installed (#235)", {
 test_that("stbl.h declares all expected function pointers (#235)", {
   h_path <- system.file("include", "stbl.h", package = "stbl")
   h_text <- paste(readLines(h_path), collapse = "\n")
-  for (sym in expected_symbols) {
+  for (sym in expected_c_symbols) {
     expect_true(
       grepl(sym, h_text, fixed = TRUE),
       label = paste0(sym, " declared in stbl.h")
@@ -78,7 +32,7 @@ test_that("stbl.h declares stbl_init_api() (#235)", {
 test_that("stbl.c assigns all expected callables via R_GetCCallable (#235)", {
   c_path <- system.file("include", "stbl.c", package = "stbl")
   c_text <- paste(readLines(c_path), collapse = "\n")
-  for (sym in expected_symbols) {
+  for (sym in expected_c_symbols) {
     expect_true(
       grepl(sym, c_text, fixed = TRUE),
       label = paste0(sym, " assigned in stbl.c")
@@ -102,7 +56,7 @@ test_that("src/init.c registers all expected C callables (#235)", {
     skip("src/init.c not accessible outside source package")
   }
   init_text <- paste(readLines(init_path), collapse = "\n")
-  for (sym in expected_symbols) {
+  for (sym in expected_c_symbols) {
     expect_true(
       grepl(sym, init_text, fixed = TRUE),
       label = paste0(sym, " registered in init.c")

--- a/tests/testthat/test-callable_c_functions.R
+++ b/tests/testthat/test-callable_c_functions.R
@@ -1,30 +1,47 @@
 expected_symbols <- c(
   # chr -> *
-  "stbl_chr_to_lgl", "stbl_chr_are_lglish",
-  "stbl_chr_to_int", "stbl_chr_are_intish",
-  "stbl_chr_to_dbl", "stbl_chr_are_dblish",
+  "stbl_chr_to_lgl",
+  "stbl_chr_are_lglish",
+  "stbl_chr_to_int",
+  "stbl_chr_are_intish",
+  "stbl_chr_to_dbl",
+  "stbl_chr_are_dblish",
   "stbl_chr_are_fctish",
   # dbl -> *
-  "stbl_dbl_to_int", "stbl_dbl_are_intish",
-  "stbl_dbl_to_lgl", "stbl_dbl_are_lglish",
+  "stbl_dbl_to_int",
+  "stbl_dbl_are_intish",
+  "stbl_dbl_to_lgl",
+  "stbl_dbl_are_lglish",
   # int -> *
-  "stbl_int_to_dbl", "stbl_int_are_dblish",
+  "stbl_int_to_dbl",
+  "stbl_int_are_dblish",
   # lgl -> *
-  "stbl_lgl_to_dbl", "stbl_lgl_are_dblish",
-  "stbl_lgl_to_int", "stbl_lgl_are_intish",
+  "stbl_lgl_to_dbl",
+  "stbl_lgl_are_dblish",
+  "stbl_lgl_to_int",
+  "stbl_lgl_are_intish",
   # cpx -> *
-  "stbl_cpx_to_dbl", "stbl_cpx_are_dblish",
-  "stbl_cpx_to_int", "stbl_cpx_are_intish",
+  "stbl_cpx_to_dbl",
+  "stbl_cpx_are_dblish",
+  "stbl_cpx_to_int",
+  "stbl_cpx_are_intish",
   # fct -> *
-  "stbl_fct_to_dbl", "stbl_fct_are_dblish",
-  "stbl_fct_to_int", "stbl_fct_are_intish",
-  "stbl_fct_to_lgl", "stbl_fct_are_lglish",
+  "stbl_fct_to_dbl",
+  "stbl_fct_are_dblish",
+  "stbl_fct_to_int",
+  "stbl_fct_are_intish",
+  "stbl_fct_to_lgl",
+  "stbl_fct_are_lglish",
   "stbl_fct_are_fctish",
   # lst -> *
-  "stbl_lst_to_dbl", "stbl_lst_to_int", "stbl_lst_to_lgl",
-  "stbl_lst_to_chr", "stbl_lst_to_fct",
+  "stbl_lst_to_dbl",
+  "stbl_lst_to_int",
+  "stbl_lst_to_lgl",
+  "stbl_lst_to_chr",
+  "stbl_lst_to_fct",
   # range checks
-  "stbl_check_min_dbl", "stbl_check_max_dbl"
+  "stbl_check_min_dbl",
+  "stbl_check_max_dbl"
 )
 
 # inst/include files -------------------------------------------------------- ----


### PR DESCRIPTION
Add `R_RegisterCCallable()` calls to `src/init.c` for all `stbl_*`
C functions, and add `inst/include/stbl.h` and `inst/include/stbl.c`
for package authors to use them via `R_GetCCallable()`.

- Closes #235
