### PR TITLE
Fix "Aguments" typo

### DIFF
--- a/R/to.R
+++ b/R/to.R
@@ -5,7 +5,7 @@
 #'
 #' @param .to A prototype that determines the target type (e.g., `integer()`,
 #'   `factor(levels = c("a", "b"))`).
-#' @param ... Aguments passed to methods and on to `to_*()` functions.
+#' @param ... Arguments passed to methods and on to `to_*()` functions.
 #' @inheritParams .shared-params
 #'
 #' @returns `x` coerced to the type of `.to`.

--- a/man/to.Rd
+++ b/man/to.Rd
@@ -110,7 +110,7 @@ to(
 \item{.to}{A prototype that determines the target type (e.g., \code{integer()},
 \code{factor(levels = c("a", "b"))}).}
 
-\item{...}{Aguments passed to methods and on to \verb{to_*()} functions.}
+\item{...}{Arguments passed to methods and on to \verb{to_*()} functions.}
 
 \item{x_arg}{\verb{(length-1 character)} The name of the argument being stabilized
 to use in error messages. The automatic value will work in most cases, or


### PR DESCRIPTION
I forgot to commit this in the previous PR, oops.