### PR TITLE
Re-complete test coverage

### DIFF
--- a/R/c_api.R
+++ b/R/c_api.R
@@ -50,6 +50,16 @@
 # dbl -> * ----
 
 #' @rdname c_x_to_y
+.dbl_to_chr <- function(x) {
+  .Call(stbl_dbl_to_chr, x)
+}
+
+#' @rdname c_x_to_y
+.dbl_are_chrish <- function(x) {
+  .Call(stbl_dbl_are_chrish, x)
+}
+
+#' @rdname c_x_to_y
 .dbl_to_int <- function(x) {
   .Call(stbl_dbl_to_int, x)
 }
@@ -67,6 +77,21 @@
 # int -> * ----
 
 #' @rdname c_x_to_y
+.int_to_chr <- function(x) {
+  .Call(stbl_int_to_chr, x)
+}
+
+#' @rdname c_x_to_y
+.int_are_chrish <- function(x) {
+  .Call(stbl_int_are_chrish, x)
+}
+
+#' @rdname c_x_to_y
+.int_to_fct <- function(x, to = NULL, ordered = FALSE) {
+  .Call(stbl_int_to_fct, x, to, ordered)
+}
+
+#' @rdname c_x_to_y
 .int_to_dbl <- function(x) {
   .Call(stbl_int_to_dbl, x)
 }
@@ -77,6 +102,16 @@
 }
 
 # lgl -> * ----
+
+#' @rdname c_x_to_y
+.lgl_to_chr <- function(x) {
+  .Call(stbl_lgl_to_chr, x)
+}
+
+#' @rdname c_x_to_y
+.lgl_are_chrish <- function(x) {
+  .Call(stbl_lgl_are_chrish, x)
+}
 
 #' @rdname c_x_to_y
 .lgl_to_dbl <- function(x) {
@@ -111,6 +146,16 @@
 }
 
 # fct -> * ----
+
+#' @rdname c_x_to_y
+.fct_to_chr <- function(x) {
+  .Call(stbl_fct_to_chr, x)
+}
+
+#' @rdname c_x_to_y
+.fct_are_chrish <- function(x) {
+  .Call(stbl_fct_are_chrish, x)
+}
 
 #' @rdname c_x_to_y
 .fct_to_dbl <- function(x) {

--- a/man/c_x_to_y.Rd
+++ b/man/c_x_to_y.Rd
@@ -8,17 +8,26 @@
 \alias{.chr_to_int}
 \alias{.chr_to_dbl}
 \alias{.chr_are_fctish}
+\alias{.dbl_to_chr}
+\alias{.dbl_are_chrish}
 \alias{.dbl_to_int}
 \alias{.dbl_to_lgl}
 \alias{.dbl_are_lglish}
+\alias{.int_to_chr}
+\alias{.int_are_chrish}
+\alias{.int_to_fct}
 \alias{.int_to_dbl}
 \alias{.int_are_dblish}
+\alias{.lgl_to_chr}
+\alias{.lgl_are_chrish}
 \alias{.lgl_to_dbl}
 \alias{.lgl_to_int}
 \alias{.lgl_are_dblish}
 \alias{.lgl_are_intish}
 \alias{.cpx_to_dbl}
 \alias{.cpx_to_int}
+\alias{.fct_to_chr}
+\alias{.fct_are_chrish}
 \alias{.fct_to_dbl}
 \alias{.fct_to_int}
 \alias{.fct_to_lgl}
@@ -45,15 +54,29 @@
 
 .chr_are_fctish(x, levels = NULL, to_na = character())
 
+.dbl_to_chr(x)
+
+.dbl_are_chrish(x)
+
 .dbl_to_int(x)
 
 .dbl_to_lgl(x)
 
 .dbl_are_lglish(x)
 
+.int_to_chr(x)
+
+.int_are_chrish(x)
+
+.int_to_fct(x, to = NULL, ordered = FALSE)
+
 .int_to_dbl(x)
 
 .int_are_dblish(x)
+
+.lgl_to_chr(x)
+
+.lgl_are_chrish(x)
 
 .lgl_to_dbl(x)
 
@@ -66,6 +89,10 @@
 .cpx_to_dbl(x)
 
 .cpx_to_int(x)
+
+.fct_to_chr(x)
+
+.fct_are_chrish(x)
 
 .fct_to_dbl(x)
 

--- a/src/chr_to_fn.c
+++ b/src/chr_to_fn.c
@@ -1,5 +1,4 @@
-#include <R.h>
-#include <Rinternals.h>
+#include "stbl.h"
 #include <R_ext/Rdynload.h>
 #include <ctype.h>
 #include <string.h>
@@ -97,37 +96,6 @@ SEXP stbl_chr_are_fnish(SEXP x) {
   return result;
 }
 
-/*
- * Build and signal a classed error condition from C so that R-side
- * try_fetch() handlers can catch it by class name.  Calling stop() with a
- * condition object always unwinds -- these helpers never return.
- */
-static void stbl_signal_classed_error(const char* cls0) {
-  SEXP nms = PROTECT(Rf_allocVector(STRSXP, 1));
-  SET_STRING_ELT(nms, 0, Rf_mkChar("message"));
-
-  SEXP cond = PROTECT(Rf_allocVector(VECSXP, 1));
-  SET_VECTOR_ELT(cond, 0, Rf_mkString(cls0)); /* message = class name */
-  Rf_setAttrib(cond, R_NamesSymbol, nms);
-
-  SEXP cls = PROTECT(Rf_allocVector(STRSXP, 3));
-  SET_STRING_ELT(cls, 0, Rf_mkChar(cls0));
-  SET_STRING_ELT(cls, 1, Rf_mkChar("error"));
-  SET_STRING_ELT(cls, 2, Rf_mkChar("condition"));
-  Rf_setAttrib(cond, R_ClassSymbol, cls);
-
-  /* UNPROTECT is unreachable after this */
-  Rf_eval(Rf_lang2(Rf_install("stop"), cond), R_BaseEnv);
-}
-
-static void stbl_signal_invalid_fn_name(void) {
-  stbl_signal_classed_error("stbl_invalid_function_name");
-}
-
-static void stbl_signal_unknown_function(void) {
-  stbl_signal_classed_error("stbl_unknown_function");
-}
-
 /* ---------------------------------------------------------------------------
  * R_tryCatchError wrappers for namespace + function lookup.
  *
@@ -158,8 +126,7 @@ static SEXP do_fn_lookup(void* data_) {
 }
 
 static SEXP handle_fn_not_found(SEXP cond, void* data_) {
-  stbl_signal_unknown_function(); /* always unwinds */
-  return R_NilValue;              /* unreachable    */
+  return signal_classed_error("stbl_unknown_function");
 }
 
 /*
@@ -181,7 +148,8 @@ SEXP stbl_chr_to_fn(SEXP x, SEXP definition_env) {
   if (*s == '\0') Rf_error("Can't convert \"\" to a function.");
 
   /* Validate colon usage via shared helper */
-  if (!is_valid_colon_usage(s)) stbl_signal_invalid_fn_name();
+  if (!is_valid_colon_usage(s))
+    return signal_classed_error("stbl_invalid_function_name");
 
   const char* sep = strstr(s, "::");
   if (sep != NULL) {

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,0 +1,26 @@
+#include <R.h>
+#include <Rinternals.h>
+
+/*
+ * Build and signal a classed error condition from C so that R-side
+ * tryCatch()/try_fetch() handlers can catch it by class name.  Returns the
+ * SEXP result of stop(), which always unwinds the R stack; the SEXP return
+ * type lets callers write "return signal_classed_error(...)" to satisfy
+ * non-void return requirements without any unreachable fallback.
+ */
+SEXP signal_classed_error(const char* cls0) {
+  SEXP nms = PROTECT(Rf_allocVector(STRSXP, 1));
+  SET_STRING_ELT(nms, 0, Rf_mkChar("message"));
+
+  SEXP cond = PROTECT(Rf_allocVector(VECSXP, 1));
+  SET_VECTOR_ELT(cond, 0, Rf_mkString(cls0)); /* message = class name */
+  Rf_setAttrib(cond, R_NamesSymbol, nms);
+
+  SEXP cls = PROTECT(Rf_allocVector(STRSXP, 3));
+  SET_STRING_ELT(cls, 0, Rf_mkChar(cls0));
+  SET_STRING_ELT(cls, 1, Rf_mkChar("error"));
+  SET_STRING_ELT(cls, 2, Rf_mkChar("condition"));
+  Rf_setAttrib(cond, R_ClassSymbol, cls);
+
+  return Rf_eval(Rf_lang2(Rf_install("stop"), cond), R_BaseEnv);
+}

--- a/src/stbl.h
+++ b/src/stbl.h
@@ -247,4 +247,10 @@ static inline void set_factor_attribs (SEXP codes, SEXP lev, int is_ordered) {
   }
 }
 
+/*
+ * Build and signal a classed error condition from C (defined in signal.c).
+ * See that file for full documentation.
+ */
+SEXP signal_classed_error(const char* cls0);
+
 #endif /* STBL_H */

--- a/tests/testthat/_snaps/to_int.md
+++ b/tests/testthat/_snaps/to_int.md
@@ -130,6 +130,46 @@
       x Can't convert some values due to non-zero complex components.
       * Locations: 4
 
+# to_int() errors for complexes that would lose precision (#noissue)
+
+    Code
+      to_int(given)
+    Condition
+      Error:
+      ! `given` <complex> must be coercible to <integer>
+      x Can't convert some values due to loss of precision.
+      * Locations: 4
+
+---
+
+    Code
+      wrapped_to_int(given)
+    Condition
+      Error in `wrapped_to_int()`:
+      ! `val` <complex> must be coercible to <integer>
+      x Can't convert some values due to loss of precision.
+      * Locations: 4
+
+---
+
+    Code
+      to_int(given)
+    Condition
+      Error:
+      ! `given` <complex> must be coercible to <integer>
+      x Can't convert some values due to loss of precision.
+      * Locations: 4
+
+---
+
+    Code
+      wrapped_to_int(given)
+    Condition
+      Error in `wrapped_to_int()`:
+      ! `val` <complex> must be coercible to <integer>
+      x Can't convert some values due to loss of precision.
+      * Locations: 4
+
 # to_int() respects coerce_factor (#14)
 
     Code

--- a/tests/testthat/test-c_api.R
+++ b/tests/testthat/test-c_api.R
@@ -342,6 +342,12 @@ test_that(".fct_to_lgl() marks non-logical levels as not valid (#226, #237)", {
   expect_identical(res[["valid"]], c(FALSE, TRUE))
 })
 
+test_that(".fct_to_lgl() converts numeric levels with trailing whitespace (#noissue)", {
+  res <- .fct_to_lgl(factor(c("1 ", "0 ")))
+  expect_identical(res[["result"]], c(TRUE, FALSE))
+  expect_identical(res[["valid"]], c(TRUE, TRUE))
+})
+
 # chr -> fct (are_fctish) ------------------------------------------------------
 
 test_that(".chr_are_fctish() returns all TRUE when levels is NULL (#226, #237)", {
@@ -755,6 +761,12 @@ test_that(".lst_to_fct() marks factor elements as valid (#226, #237)", {
   expect_identical(res[["valid"]], TRUE)
 })
 
+test_that(".lst_to_fct() treats NA factor element as NA_character_ and valid (#noissue)", {
+  res <- .lst_to_fct(list(factor(NA_character_)))
+  expect_identical(res[["result"]], NA_character_)
+  expect_identical(res[["valid"]], TRUE)
+})
+
 test_that(".lst_to_fct() unpacks a one-element list with a character vector (#237)", {
   res <- .lst_to_fct(list(c("a", "b")))
   expect_identical(res[["result"]], c("a", "b"))
@@ -1111,4 +1123,262 @@ test_that(".check_max_dbl() handles integer input (#220)", {
   expect_null(.check_max_dbl(c(1L, 2L), 3.0))
   expect_identical(.check_max_dbl(c(1L, 2L, 3L), 2.0), 3L)
   expect_null(.check_max_dbl(c(NA_integer_, 1L), 2.0))
+})
+
+# dbl -> chr -------------------------------------------------------------------
+
+test_that(".dbl_to_chr() converts doubles to character (#noissue)", {
+  res <- .dbl_to_chr(c(1.5, -3.14, NA_real_))
+  expect_identical(res[["result"]], c("1.5", "-3.14", NA_character_))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+# dbl -> chr (are_chrish) ------------------------------------------------------
+
+test_that(".dbl_are_chrish() returns all TRUE (#noissue)", {
+  expect_identical(.dbl_are_chrish(c(1.5, NA_real_, Inf)), rep(TRUE, 3))
+})
+
+# int -> chr -------------------------------------------------------------------
+
+test_that(".int_to_chr() converts integers to character (#noissue)", {
+  res <- .int_to_chr(c(1L, -3L, NA_integer_))
+  expect_identical(res[["result"]], c("1", "-3", NA_character_))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+# int -> chr (are_chrish) ------------------------------------------------------
+
+test_that(".int_are_chrish() returns all TRUE (#noissue)", {
+  expect_identical(.int_are_chrish(c(1L, NA_integer_, 0L)), rep(TRUE, 3))
+})
+
+# lgl -> chr -------------------------------------------------------------------
+
+test_that(".lgl_to_chr() converts logicals to character (#noissue)", {
+  res <- .lgl_to_chr(c(TRUE, FALSE, NA))
+  expect_identical(res[["result"]], c("TRUE", "FALSE", NA_character_))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+# lgl -> chr (are_chrish) ------------------------------------------------------
+
+test_that(".lgl_are_chrish() returns all TRUE (#noissue)", {
+  expect_identical(.lgl_are_chrish(c(TRUE, FALSE, NA)), rep(TRUE, 3))
+})
+
+# fct -> chr -------------------------------------------------------------------
+
+test_that(".fct_to_chr() handles a malformed factor code gracefully (#noissue)", {
+  # A factor with a code that exceeds the number of levels is malformed.
+  bad_fct <- structure(3L, levels = c("a", "b"), class = "factor")
+  res <- .fct_to_chr(bad_fct)
+  expect_identical(res[["result"]], NA_character_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+# fct -> chr (are_chrish) ------------------------------------------------------
+
+test_that(".fct_are_chrish() returns TRUE for valid and NA codes (#noissue)", {
+  expect_identical(
+    .fct_are_chrish(factor(c("a", "b", NA))),
+    c(TRUE, TRUE, TRUE)
+  )
+})
+
+test_that(".fct_are_chrish() returns FALSE for out-of-range factor codes (#noissue)", {
+  bad_fct <- structure(c(1L, 3L), levels = c("a", "b"), class = "factor")
+  expect_identical(.fct_are_chrish(bad_fct), c(TRUE, FALSE))
+})
+
+# fct -> fct (are_fctish, to_na) -----------------------------------------------
+
+test_that(".fct_are_fctish() treats to_na values as fctish (#noissue)", {
+  f <- factor(c("a", "z", NA))
+  expect_identical(
+    .fct_are_fctish(f, levels = c("a", "b"), to_na = "z"),
+    c(TRUE, TRUE, TRUE)
+  )
+})
+
+# int -> fct -------------------------------------------------------------------
+
+test_that(".int_to_fct() marks integers not matching any level as not valid (#noissue)", {
+  res <- .int_to_fct(5L, c("1", "2"), FALSE)
+  expect_true(is.na(res[["result"]]))
+  expect_identical(res[["valid"]], FALSE)
+})
+
+# chr -> fn (dotted name) ------------------------------------------------------
+
+test_that(".chr_to_fn() works for dot-prefixed function names (#noissue)", {
+  expect_identical(.chr_to_fn(".libPaths"), .libPaths)
+})
+
+test_that(".chr_are_fnish() returns TRUE for a dot-prefixed identifier (#noissue)", {
+  expect_identical(.chr_are_fnish(".foo"), TRUE)
+})
+
+# lst -> dbl (fill_vec paths) --------------------------------------------------
+
+test_that(".lst_to_dbl() unpacks a one-element list with a logical vector (#noissue)", {
+  res <- .lst_to_dbl(list(c(TRUE, FALSE, NA)))
+  expect_identical(res[["result"]], c(1.0, 0.0, NA_real_))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+test_that(".lst_to_dbl() unpacks a one-element list with a complex vector (#noissue)", {
+  res <- .lst_to_dbl(list(c(1 + 0i, -2 + 0i)))
+  expect_identical(res[["result"]], c(1.0, -2.0))
+  expect_identical(res[["valid"]], c(TRUE, TRUE))
+})
+
+test_that(".lst_to_dbl() unpacks a one-element list with a factor vector (#noissue)", {
+  res <- .lst_to_dbl(list(factor(c("1.5", "a"))))
+  expect_identical(res[["result"]], c(1.5, NA_real_))
+  expect_identical(res[["valid"]], c(TRUE, FALSE))
+})
+
+test_that(".lst_to_dbl() passes NA factor element through; valid TRUE (#noissue)", {
+  res <- .lst_to_dbl(list(factor(NA_character_)))
+  expect_identical(res[["result"]], NA_real_)
+  expect_identical(res[["valid"]], TRUE)
+})
+
+test_that(".lst_to_dbl() passes NA complex through; valid TRUE (#noissue)", {
+  res <- .lst_to_dbl(list(NA_complex_))
+  expect_identical(res[["result"]], NA_real_)
+  expect_identical(res[["valid"]], TRUE)
+})
+
+test_that(".lst_to_dbl() marks non-atomic scalar elements as not valid (#noissue)", {
+  res <- .lst_to_dbl(list(as.raw(1)))
+  expect_identical(res[["result"]], NA_real_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+test_that(".lst_to_dbl() marks NaN strings as not valid (#noissue)", {
+  res <- .lst_to_dbl(list("NaN"))
+  expect_identical(res[["result"]], NA_real_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+# lst -> int (fill_vec paths) --------------------------------------------------
+
+test_that(".lst_to_int() unpacks a one-element list with a logical vector (#noissue)", {
+  res <- .lst_to_int(list(c(TRUE, FALSE, NA)))
+  expect_identical(res[["result"]], c(1L, 0L, NA_integer_))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+test_that(".lst_to_int() unpacks a one-element list with a factor vector (#noissue)", {
+  res <- .lst_to_int(list(factor(c("1", "a"))))
+  expect_identical(res[["result"]], c(1L, NA_integer_))
+  expect_identical(res[["valid"]], c(TRUE, FALSE))
+})
+
+test_that(".lst_to_int() unpacks a one-element list with a complex vector (#noissue)", {
+  res <- .lst_to_int(list(c(2 + 0i, 1 + 1i)))
+  expect_identical(res[["result"]], c(2L, NA_integer_))
+  expect_identical(res[["valid"]], c(TRUE, FALSE))
+})
+
+test_that(".lst_to_int() unpacks one-element list with fractional-real complex vector (#noissue)", {
+  res <- .lst_to_int(list(c(1.5 + 0i, 2 + 0i)))
+  expect_identical(res[["result"]], c(NA_integer_, 2L))
+  expect_identical(res[["valid"]], c(FALSE, TRUE))
+})
+
+test_that(".lst_to_int() unpacks one-element list with fractional double vector (#noissue)", {
+  res <- .lst_to_int(list(c(1.0, 1.5)))
+  expect_identical(res[["result"]], c(1L, NA_integer_))
+  expect_identical(res[["valid"]], c(TRUE, FALSE))
+})
+
+test_that(".lst_to_int() passes NA factor element through; valid TRUE (#noissue)", {
+  res <- .lst_to_int(list(factor(NA_character_)))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], TRUE)
+})
+
+test_that(".lst_to_int() passes NA complex through; valid TRUE (#noissue)", {
+  res <- .lst_to_int(list(NA_complex_))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], TRUE)
+})
+
+test_that(".lst_to_int() marks fractional complex scalar as not valid (#noissue)", {
+  res <- .lst_to_int(list(1.5 + 0i))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+test_that(".lst_to_int() marks non-atomic scalar elements as not valid (#noissue)", {
+  res <- .lst_to_int(list(as.raw(1)))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+test_that(".lst_to_int() marks NaN strings as not valid (#noissue)", {
+  res <- .lst_to_int(list("NaN"))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+test_that(".lst_to_int() marks Inf strings as not valid (#noissue)", {
+  res <- .lst_to_int(list("Inf"))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+test_that(".lst_to_int() passes NA double through; valid TRUE (#noissue)", {
+  res <- .lst_to_int(list(NA_real_))
+  expect_identical(res[["result"]], NA_integer_)
+  expect_identical(res[["valid"]], TRUE)
+})
+
+# lst -> lgl (fill_vec paths) --------------------------------------------------
+
+test_that(".lst_to_lgl() unpacks a one-element list with an integer vector (#noissue)", {
+  res <- .lst_to_lgl(list(c(0L, 1L, NA_integer_)))
+  expect_identical(res[["result"]], c(FALSE, TRUE, NA))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+test_that(".lst_to_lgl() unpacks a one-element list with a double vector (#noissue)", {
+  res <- .lst_to_lgl(list(c(0.0, 1.5, NA_real_)))
+  expect_identical(res[["result"]], c(FALSE, TRUE, NA))
+  expect_identical(res[["valid"]], c(TRUE, TRUE, TRUE))
+})
+
+test_that(".lst_to_lgl() unpacks a one-element list with a factor vector (#noissue)", {
+  res <- .lst_to_lgl(list(factor(c("TRUE", "a", NA))))
+  expect_identical(res[["result"]], c(TRUE, NA, NA))
+  expect_identical(res[["valid"]], c(TRUE, FALSE, TRUE))
+})
+
+test_that(".lst_to_lgl() passes NA factor element through; valid TRUE (#noissue)", {
+  res <- .lst_to_lgl(list(factor(NA_character_)))
+  expect_identical(res[["result"]], NA)
+  expect_identical(res[["valid"]], TRUE)
+})
+
+test_that(".lst_to_lgl() marks non-atomic scalar elements as not valid (#noissue)", {
+  res <- .lst_to_lgl(list(as.raw(1)))
+  expect_identical(res[["result"]], NA)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+test_that(".lst_to_lgl() marks NaN numeric strings as not valid (#noissue)", {
+  res <- .lst_to_lgl(list("NaN"))
+  expect_identical(res[["result"]], NA)
+  expect_identical(res[["valid"]], FALSE)
+})
+
+# lst -> chr (default branch) --------------------------------------------------
+
+test_that(".lst_to_chr() marks raw scalar elements as not valid (#noissue)", {
+  res <- .lst_to_chr(list(as.raw(1)))
+  expect_identical(res[["result"]], NA_character_)
+  expect_identical(res[["valid"]], FALSE)
 })

--- a/tests/testthat/test-to_int.R
+++ b/tests/testthat/test-to_int.R
@@ -144,6 +144,37 @@ test_that("to_int() errors informatively for bad complexes (#2)", {
   )
 })
 
+test_that("to_int() errors for complexes that would lose precision (#noissue)", {
+  given <- as.complex(1:10)
+  given[[4]] <- 1.5 + 0i
+  expect_error(
+    to_int(given),
+    class = .compile_dash("stbl", "error", "incompatible_type")
+  )
+  expect_snapshot(
+    to_int(given),
+    error = TRUE
+  )
+  expect_snapshot(
+    wrapped_to_int(given),
+    error = TRUE
+  )
+
+  given[[4]] <- Inf + 0i
+  expect_error(
+    to_int(given),
+    class = .compile_dash("stbl", "error", "incompatible_type")
+  )
+  expect_snapshot(
+    to_int(given),
+    error = TRUE
+  )
+  expect_snapshot(
+    wrapped_to_int(given),
+    error = TRUE
+  )
+})
+
 test_that("to_int() works for factors (#4)", {
   expected <- c(1L, 3L, 5L, 7L)
   given <- factor(expected)


### PR DESCRIPTION
We dropped below 100% at some point. This fixes that. I also abstracted the relatively new `signal_classed_error()` into a new `src/signal.c`.